### PR TITLE
Check if Authenticator is loading before attempting to login

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,9 +27,11 @@
     "jest": "23.6.0",
     "jest-localstorage-mock": "^2.4.0",
     "jsdom": "^13.2.0",
+    "promise": "^8.0.3",
     "ts-jest": "^23.10.5",
     "tslint": "^5.11.0",
-    "typescript": "^3.2.2"
+    "typescript": "^3.2.2",
+    "waait": "^1.0.4"
   },
   "jest": {
     "setupFiles": [

--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
     "promise": "^8.0.3",
     "ts-jest": "^23.10.5",
     "tslint": "^5.11.0",
-    "typescript": "^3.2.2",
-    "waait": "^1.0.4"
+    "typescript": "^3.2.2"
   },
   "jest": {
     "setupFiles": [

--- a/src/UALJs.test.ts
+++ b/src/UALJs.test.ts
@@ -225,7 +225,7 @@ const sleep = (time: number) => {
 const runPromises = async () => {
   // jest.useFakeTimers() changes the order in which promises are run
   // https://github.com/facebook/jest/pull/6876
-  // below is a workaround to ensure promises are run in their intended order
+  // the code below along with the global.Promise pollyfill are a workaround to ensure promises are run in their intended order
   Promise.resolve().then(() => jest.advanceTimersByTime(1))
   await sleep(1)
 }

--- a/src/UALJs.test.ts
+++ b/src/UALJs.test.ts
@@ -1,5 +1,4 @@
 import 'jest-localstorage-mock'
-import wait from 'waait'
 import { User, Authenticator } from 'universal-authenticator-library'
 import { UALJs } from './UALJs'
 
@@ -210,7 +209,7 @@ describe('Authenticators', () => {
       authenticator.login = login
 
       ual = createNewUALJs(authenticator, containerElement)
-      
+
       ual.init()
       await waitForPromises()
 
@@ -219,10 +218,14 @@ describe('Authenticators', () => {
   })
 })
 
+const sleep = (time: number) => {
+  return new Promise((resolve) => setTimeout(resolve, time));
+}
+
 const waitForPromises = async () => {
   // this ensures promises are awaited which currently do not due to the use of jestFakeTimers
   Promise.resolve().then(() => jest.advanceTimersByTime(1))
-  await wait(1)
+  await sleep(1)
 }
 
 const createNewUALJs = (authenticator: Authenticator, containerElement: HTMLElement) => {

--- a/src/UALJs.test.ts
+++ b/src/UALJs.test.ts
@@ -1,12 +1,13 @@
 import 'jest-localstorage-mock'
-import { User, Authenticator } from 'universal-authenticator-library'
+import promisePolyFill from 'promise'
+import { Authenticator, User } from 'universal-authenticator-library'
 import { UALJs } from './UALJs'
 
 import { AutologinAuthenticator } from './AuthMocks/AutologinAuthenticator'
 import { BaseMockAuthenticator } from './AuthMocks/BaseMockAuthenticator'
 
 jest.useFakeTimers()
-global.Promise = require('promise')
+global.Promise = promisePolyFill
 
 describe('Authenticators', () => {
   let containerElement: HTMLElement
@@ -66,10 +67,10 @@ describe('Authenticators', () => {
       authenticator.isLoading = jest.fn().mockReturnValue(true)
 
       ual = createNewUALJs(authenticator, containerElement)
-        
+
       ual.init()
       ual.loginUser(authenticator)
-      
+
       expect(authenticator.isLoading).toHaveBeenCalled()
       expect(authenticator.login).not.toHaveBeenCalled()
     })
@@ -87,7 +88,7 @@ describe('Authenticators', () => {
       expect(authenticator.login).not.toHaveBeenCalled()
 
       authenticator.isLoading = jest.fn().mockReturnValue(false)
-      
+
       jest.advanceTimersByTime(250)
       await promise
 
@@ -139,7 +140,7 @@ describe('Authenticators', () => {
 
       expect(authenticator.login).not.toHaveBeenCalled()
     })
-  
+
     it('logs in for non account name required', async () => {
       const thirtyDaysFromNow = new Date(new Date().getTime() + (30 * 24 * 60 * 60 * 1000))
 
@@ -161,7 +162,7 @@ describe('Authenticators', () => {
       localStorage.setItem('ual-session-expiration', `${thirtyDaysFromNow.getTime()}`)
       localStorage.setItem('ual-session-authenticator', authenticator.constructor.name)
       localStorage.setItem('ual-session-account-name', 'reqacctname')
-      
+
       ual.init()
       await runPromises()
 
@@ -171,7 +172,6 @@ describe('Authenticators', () => {
     it('are set on login when account name is not required', async () => {
       ual.init()
       await ual.loginUser(authenticator)
-
 
       expect(localStorage.getItem('ual-session-expiration')).not.toBeNull()
       expect(localStorage.getItem('ual-session-authenticator')).toEqual(authenticator.constructor.name)
@@ -219,13 +219,14 @@ describe('Authenticators', () => {
 })
 
 const sleep = (time: number) => {
-  return new Promise((resolve) => setTimeout(resolve, time));
+  return new Promise((resolve) => setTimeout(resolve, time))
 }
 
 const runPromises = async () => {
   // jest.useFakeTimers() changes the order in which promises are run
   // https://github.com/facebook/jest/pull/6876
-  // the code below along with the global.Promise pollyfill are a workaround to ensure promises are run in their intended order
+  // the code below along with the global.Promise pollyfill
+  // are workarounds to ensure promises are run in their intended order
   Promise.resolve().then(() => jest.advanceTimersByTime(1))
   await sleep(1)
 }
@@ -236,7 +237,8 @@ const createNewUALJs = (authenticator: Authenticator, containerElement: HTMLElem
     [],
     'my cool app',
     [authenticator],
-  {
-    containerElement
-  })
+    {
+      containerElement
+    }
+  )
 }

--- a/src/UALJs.test.ts
+++ b/src/UALJs.test.ts
@@ -7,6 +7,8 @@ import { AutologinAuthenticator } from './AuthMocks/AutologinAuthenticator'
 import { BaseMockAuthenticator } from './AuthMocks/BaseMockAuthenticator'
 
 jest.useFakeTimers()
+// Issue with promise run order when using useFakeTimers: https://github.com/facebook/jest/pull/6876
+// Workaround: https://github.com/facebook/jest/issues/7151
 global.Promise = promisePolyFill
 
 describe('Authenticators', () => {
@@ -216,15 +218,16 @@ const sleep = (time: number) => {
 
 const runPromises = async () => {
   // jest.useFakeTimers() changes the order in which promises are run
-  // https://github.com/facebook/jest/pull/6876
+  // Issue: https://github.com/facebook/jest/pull/6876
+  // Workaround: https://github.com/facebook/jest/issues/7151
   // the code below along with the global.Promise pollyfill
   // are workarounds to ensure promises are run in their intended order
   Promise.resolve().then(() => jest.advanceTimersByTime(1))
   await sleep(1)
 }
 
-const createNewUALJs = (authenticator: Authenticator, containerElement: HTMLElement) => {
-  return new UALJs(
+const createNewUALJs = (authenticator: Authenticator, containerElement: HTMLElement) => (
+  new UALJs(
     () => true,
     [],
     'my cool app',
@@ -233,4 +236,4 @@ const createNewUALJs = (authenticator: Authenticator, containerElement: HTMLElem
       containerElement
     }
   )
-}
+)

--- a/src/UALJs.test.ts
+++ b/src/UALJs.test.ts
@@ -126,14 +126,6 @@ describe('Authenticators', () => {
   })
 
   describe('session login', () => {
-    beforeEach(() => {
-      authenticator = new BaseMockAuthenticator([], null)
-      authenticator.login = login
-      authenticator.isLoading = isLoading
-
-      ual = createNewUALJs(authenticator, containerElement)
-    })
-
     it('does not login automatically when there is not a stored session state', async () => {
       ual.init()
       await runPromises()

--- a/src/UALJs.test.ts
+++ b/src/UALJs.test.ts
@@ -7,7 +7,8 @@ import { AutologinAuthenticator } from './AuthMocks/AutologinAuthenticator'
 import { BaseMockAuthenticator } from './AuthMocks/BaseMockAuthenticator'
 
 jest.useFakeTimers()
-// Issue with promise run order when using useFakeTimers: https://github.com/facebook/jest/pull/6876
+// jest.useFakeTimers() changes the order in which promises are run
+// Issue: https://github.com/facebook/jest/pull/6876
 // Workaround: https://github.com/facebook/jest/issues/7151
 global.Promise = promisePolyFill
 

--- a/src/UALJs.test.ts
+++ b/src/UALJs.test.ts
@@ -135,7 +135,7 @@ describe('Authenticators', () => {
 
     it('does not login automatically when there is not a stored session state', async () => {
       ual.init()
-      await waitForPromises()
+      await runPromises()
 
       expect(authenticator.login).not.toHaveBeenCalled()
     })
@@ -147,7 +147,7 @@ describe('Authenticators', () => {
       localStorage.setItem('ual-session-authenticator', authenticator.constructor.name)
 
       ual.init()
-      await waitForPromises()
+      await runPromises()
 
       expect(authenticator.login).toHaveBeenCalled()
     })
@@ -163,7 +163,7 @@ describe('Authenticators', () => {
       localStorage.setItem('ual-session-account-name', 'reqacctname')
       
       ual.init()
-      await waitForPromises()
+      await runPromises()
 
       expect(authenticator.login).toHaveBeenCalledWith('reqacctname')
     })
@@ -199,7 +199,7 @@ describe('Authenticators', () => {
       ual = createNewUALJs(authenticator, containerElement)
 
       ual.init()
-      await waitForPromises()
+      await runPromises()
 
       expect(authenticator.login).toBeCalledTimes(1)
     })
@@ -211,7 +211,7 @@ describe('Authenticators', () => {
       ual = createNewUALJs(authenticator, containerElement)
 
       ual.init()
-      await waitForPromises()
+      await runPromises()
 
       expect(authenticator.login).not.toBeCalled()
     })
@@ -222,8 +222,10 @@ const sleep = (time: number) => {
   return new Promise((resolve) => setTimeout(resolve, time));
 }
 
-const waitForPromises = async () => {
-  // this ensures promises are awaited which currently do not due to the use of jestFakeTimers
+const runPromises = async () => {
+  // jest.useFakeTimers() changes the order in which promises are run
+  // https://github.com/facebook/jest/pull/6876
+  // below is a workaround to ensure promises are run in their intended order
   Promise.resolve().then(() => jest.advanceTimersByTime(1))
   await sleep(1)
 }

--- a/src/UALJs.ts
+++ b/src/UALJs.ts
@@ -20,6 +20,8 @@ export class UALJs extends UAL {
   protected static SESSION_AUTHENTICATOR_KEY = 'ual-session-authenticator'
   protected static SESSION_ACCOUNT_NAME_KEY = 'ual-session-account-name'
 
+  protected static AUTHENTICATOR_LOADING_INTERVAL = 250
+
   protected userCallbackHandler: (users: User[]) => any
   protected accountNameInputValue: string = ''
   protected dom?: UALJsDom
@@ -55,14 +57,14 @@ export class UALJs extends UAL {
   }
 
   /**
-   * Initializes UAL: If a renderConfig was provided and no autlogin authenticator
-   * is returned it will render the Auth Button and relevent DOM elements.
+   * Initializes UAL: If a renderConfig was provided and no autologin authenticator
+   * is returned it will render the Auth Button and relevant DOM elements.
    *
    */
   public init(): void {
     const authenticators = this.getAuthenticators()
 
-    // peform this check first, if we're autologging in we don't render a dom
+    // perform this check first, if we're autologging in we don't render a dom
     if (!!authenticators.autoLoginAuthenticator) {
       this.isAutologin = true
       this.loginUser(authenticators.autoLoginAuthenticator)
@@ -73,7 +75,7 @@ export class UALJs extends UAL {
       this.attemptSessionLogin(authenticators.availableAuthenticators)
 
       if (!this.renderConfig) {
-        throw new Error('Render Configuaration is required when no auto login authenticator is provided')
+        throw new Error('Render Configuration is required when no auto login authenticator is provided')
       }
 
       const {
@@ -108,7 +110,13 @@ export class UALJs extends UAL {
         ) as Authenticator
 
         const accountName = localStorage.getItem(UALJs.SESSION_ACCOUNT_NAME_KEY) || undefined
-        this.loginUser(sessionAuthenticator, accountName)
+
+        const authenticatorIsLoadingCheck = setInterval(() => {
+          if (!sessionAuthenticator.isLoading()) {
+            clearInterval(authenticatorIsLoadingCheck)
+            this.loginUser(sessionAuthenticator, accountName)
+          }
+        }, UALJs.AUTHENTICATOR_LOADING_INTERVAL)
       }
     }
   }

--- a/src/UALJs.ts
+++ b/src/UALJs.ts
@@ -113,21 +113,6 @@ export class UALJs extends UAL {
     }
   }
 
-  private async isAuthenticatorLoading(authenticator: Authenticator) {
-    return new Promise((resolve) => {
-      if (!authenticator.isLoading()) {
-        resolve()
-        return
-      }
-      const authenticatorIsLoadingCheck = setInterval(() => {
-        if (!authenticator.isLoading()) {
-          clearInterval(authenticatorIsLoadingCheck)
-          resolve()
-        }
-      }, UALJs.AUTHENTICATOR_LOADING_INTERVAL)
-    })
-  }
-
   /**
    * App developer can call this directly with the preferred authenticator or render a
    * UI to let the user select their authenticator
@@ -163,6 +148,21 @@ export class UALJs extends UAL {
     if (!this.isAutologin) {
       this.dom!.reset()
     }
+  }
+
+  private async isAuthenticatorLoading(authenticator: Authenticator) {
+    return new Promise((resolve) => {
+      if (!authenticator.isLoading()) {
+        resolve()
+        return
+      }
+      const authenticatorIsLoadingCheck = setInterval(() => {
+        if (!authenticator.isLoading()) {
+          clearInterval(authenticatorIsLoadingCheck)
+          resolve()
+        }
+      }, UALJs.AUTHENTICATOR_LOADING_INTERVAL)
+    })
   }
 
   /**

--- a/src/UALJs.ts
+++ b/src/UALJs.ts
@@ -108,7 +108,6 @@ export class UALJs extends UAL {
         ) as Authenticator
 
         const accountName = localStorage.getItem(UALJs.SESSION_ACCOUNT_NAME_KEY) || undefined
-
         this.loginUser(sessionAuthenticator, accountName)
       }
     }

--- a/src/UALJs.ts
+++ b/src/UALJs.ts
@@ -131,7 +131,7 @@ export class UALJs extends UAL {
     localStorage.setItem(UALJs.SESSION_EXPIRATION_KEY, `${thirtyDaysFromNow.getTime()}`)
     localStorage.setItem(UALJs.SESSION_AUTHENTICATOR_KEY, authenticator.constructor.name)
 
-    await this.isAuthenticatorLoading(authenticator)
+    await this.waitForAuthenticatorToLoad(authenticator)
 
     if (accountName) {
       users = await authenticator.login(accountName)
@@ -150,7 +150,7 @@ export class UALJs extends UAL {
     }
   }
 
-  private async isAuthenticatorLoading(authenticator: Authenticator) {
+  private async waitForAuthenticatorToLoad(authenticator: Authenticator) {
     return new Promise((resolve) => {
       if (!authenticator.isLoading()) {
         resolve()

--- a/src/UALJsDom.ts
+++ b/src/UALJsDom.ts
@@ -199,7 +199,7 @@ export class UALJsDom {
   }
 
   /**
-   * Genarates unique string for comparing authenticator states
+   * Generates unique string for comparing authenticator states
    */
   private getAuthenticatorsStateString(): string {
 
@@ -439,7 +439,7 @@ export class UALJsDom {
   }
 
   /**
-   * Handles the click action of Autenticator buttons
+   * Handles the click action of Authenticator buttons
    *
    * @param authenticators Authenticators
    */

--- a/yarn.lock
+++ b/yarn.lock
@@ -197,6 +197,11 @@ arrify@^1.0.1:
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
   integrity sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=
 
+asap@~2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
+  integrity sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=
+
 asn1@~0.2.3:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.4.tgz#8d2475dfab553bb33e77b54e59e880bb8ce23136"
@@ -2811,6 +2816,13 @@ process-nextick-args@~2.0.0:
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
   integrity sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==
 
+promise@^8.0.3:
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/promise/-/promise-8.0.3.tgz#f592e099c6cddc000d538ee7283bb190452b0bf6"
+  integrity sha512-HeRDUL1RJiLhyA0/grn+PTShlBAcLuh/1BJGtrvjwbvRDCTLLMEz9rOGCV+R3vHY4MixIuoMEd9Yq/XvsTPcjw==
+  dependencies:
+    asap "~2.0.6"
+
 prompts@^0.1.9:
   version "0.1.14"
   resolved "https://registry.yarnpkg.com/prompts/-/prompts-0.1.14.tgz#a8e15c612c5c9ec8f8111847df3337c9cbd443b2"
@@ -3657,6 +3669,11 @@ w3c-xmlserializer@^1.0.1:
     domexception "^1.0.1"
     webidl-conversions "^4.0.2"
     xml-name-validator "^3.0.0"
+
+waait@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/waait/-/waait-1.0.4.tgz#1d177bab3175bfb56f0f832526582e0ca0b2650d"
+  integrity sha512-fMUqZH5xkzDgzw3b0CzOq7IBjIx9ig09gnpnRpRgonbPOZJWGURXWWHWt3xJa8cpxjh1WGFzRAD96V8i2C8Wmg==
 
 walker@~1.0.5:
   version "1.0.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3670,11 +3670,6 @@ w3c-xmlserializer@^1.0.1:
     webidl-conversions "^4.0.2"
     xml-name-validator "^3.0.0"
 
-waait@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/waait/-/waait-1.0.4.tgz#1d177bab3175bfb56f0f832526582e0ca0b2650d"
-  integrity sha512-fMUqZH5xkzDgzw3b0CzOq7IBjIx9ig09gnpnRpRgonbPOZJWGURXWWHWt3xJa8cpxjh1WGFzRAD96V8i2C8Wmg==
-
 walker@~1.0.5:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/walker/-/walker-1.0.7.tgz#2f7f9b8fd10d677262b18a884e28d19618e028fb"


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
Session persistence was broken due to attempts to login before the Authenticator was ready. By checking that the Authenticator is not loading before attempting to login, session persistence is now functional.  Fixes #31

## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
